### PR TITLE
fix: detect mainnet fork correctly

### DIFF
--- a/utils/config.py
+++ b/utils/config.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from brownie import network, accounts
+from brownie import network, accounts, rpc
 
 
 ldo_token_address = '0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32'
@@ -12,7 +12,7 @@ lido_dao_token_manager_address = '0xf73a1260d222f447210581DDf212D915c09a3249'
 
 
 def get_is_live():
-    return network.show_active() != 'development'
+    return not rpc.is_active()
 
 
 def get_deployer_account(is_live):


### PR DESCRIPTION
This changes how development network is detected to a recommended method and fixes a bug with `mainnet-fork` being considered a live network.
